### PR TITLE
fix: move chain enforcement to Web3Provider level

### DIFF
--- a/app/(tabs)/(me)/index.tsx
+++ b/app/(tabs)/(me)/index.tsx
@@ -5,15 +5,14 @@ import { Text, View, useThemeColor } from '@/components/Themed';
 import { AppKitButton } from '@reown/appkit-wagmi-react-native';
 import { Stack, Link } from 'expo-router';
 import { Image } from 'expo-image';
-import { useAccount, useChainId, useSwitchChain } from "wagmi";
+import { useAccount } from "wagmi";
 import { graphql } from '@/lib/graphql';
 import { useQuery } from '@tanstack/react-query';
 import { execute } from '@/lib/graphql/execute';
 import { blurhash, getCachedImage } from '@/lib/utils';
 import { CrossPlatformPicker } from '@/components/CrossPlatformPicker';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { intuitionTestnet } from '@0xintuition/protocol';
 const AccountProfileQuery = graphql(`
 query AccountProfile($accountId: String!, $positionsBool: positions_bool_exp) {
   account(id: $accountId) {
@@ -147,14 +146,6 @@ export default function MeIndex() {
   const { address, status } = useAccount();
   const backgroundColor = useThemeColor({}, 'background');
   const [sourceIndex, setSourceIndex] = useState(0);
-  const { switchChain } = useSwitchChain()
-  const chainId = useChainId()
-
-  useEffect(() => {
-    if (chainId !== intuitionTestnet.id) {
-      switchChain({ chainId: intuitionTestnet.id })
-    }
-  }, [chainId]);
 
   const { data, isLoading } = useQuery({
     enabled: !!address,

--- a/config/web3/wagmi.ts
+++ b/config/web3/wagmi.ts
@@ -1,6 +1,5 @@
 import { defaultWagmiConfig } from "@reown/appkit-wagmi-react-native";
 import { authConnector } from "@reown/appkit-auth-wagmi-react-native";
-import { mainnet } from "@wagmi/core/chains";
 import { intuitionTestnet } from "@0xintuition/protocol";
 
 export const projectId = "9894a080a383df0833d5e82404186fdd";

--- a/providers/Web3Provider.tsx
+++ b/providers/Web3Provider.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { WagmiProvider } from "wagmi";
+import React, { useEffect } from 'react';
+import { WagmiProvider, useAccount, useChainId, useSwitchChain } from "wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppKit } from "@reown/appkit-wagmi-react-native";
 import { wagmiConfig, createWeb3AppKit } from "@/config/web3";
+import { intuitionTestnet } from "@0xintuition/protocol";
 
 const queryClient = new QueryClient();
 
@@ -12,10 +13,25 @@ interface Web3ProviderProps {
   children: React.ReactNode;
 }
 
+function ChainEnforcer() {
+  const { status } = useAccount();
+  const chainId = useChainId();
+  const { switchChain } = useSwitchChain();
+
+  useEffect(() => {
+    if (status === 'connected' && chainId && chainId !== intuitionTestnet.id) {
+      switchChain({ chainId: intuitionTestnet.id });
+    }
+  }, [chainId, status, switchChain]);
+
+  return null;
+}
+
 export function Web3Provider({ children }: Web3ProviderProps) {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
+        <ChainEnforcer />
         {children}
         <AppKit />
       </QueryClientProvider>


### PR DESCRIPTION
## Summary
- Moved chain enforcement logic from the me tab component to the Web3Provider level for global application
- Removed unused mainnet import from wagmi config
- Added ChainEnforcer component that automatically switches to intuitionTestnet when a wallet connects on the wrong chain
- Ensures chain switching only occurs when wallet is connected and chainId is defined

## Test plan
- [ ] Connect wallet on a different chain and verify it automatically switches to intuitionTestnet
- [ ] Navigate between tabs and verify chain remains on intuitionTestnet
- [ ] Disconnect and reconnect wallet to verify no errors occur during chain initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)