### PR TITLE
feat: add native touch feedback to interactive elements

### DIFF
--- a/app/(tabs)/(explore)/index.tsx
+++ b/app/(tabs)/(explore)/index.tsx
@@ -157,7 +157,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, href, isLast }) => {
   return (
     <Link href={href} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           {item.cached_image?.url && (
@@ -205,7 +210,12 @@ const ClaimItem: React.FC<ClaimItemProps> = ({
   return (
     <Link href={`/(explore)/triple/${triple.term_id}`} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           <View style={styles.claimTextContainer}>
@@ -378,6 +388,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     justifyContent: 'center',
+  },
+  sectionItemPressed: {
+    opacity: 0.7,
   },
   sectionItemContent: {
     paddingVertical: 3,

--- a/app/(tabs)/(explore,me,lists)/atom/[id].tsx
+++ b/app/(tabs)/(explore,me,lists)/atom/[id].tsx
@@ -77,7 +77,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, isLast }) => {
   return (
     <Link href={`../list/${item.term_id}` as any} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           {item.cached_image?.url && (
@@ -250,6 +255,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     justifyContent: 'center',
+  },
+  sectionItemPressed: {
+    opacity: 0.7,
   },
   sectionItemContent: {
     paddingVertical: 3,

--- a/app/(tabs)/(explore,me,lists)/list/[id].tsx
+++ b/app/(tabs)/(explore,me,lists)/list/[id].tsx
@@ -71,7 +71,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, isLast }) => {
   return (
     <Link href={`../atom/${item.term_id}`} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           {item.cached_image?.url && (
@@ -269,6 +274,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     justifyContent: 'center',
+  },
+  sectionItemPressed: {
+    opacity: 0.7,
   },
   sectionItemContent: {
     paddingVertical: 3,

--- a/app/(tabs)/(explore,me,lists)/triple/[id].tsx
+++ b/app/(tabs)/(explore,me,lists)/triple/[id].tsx
@@ -225,7 +225,13 @@ const CreatorSection: React.FC<{
 
   return (
     <Link href={`../account/${creator.id}` as any} asChild>
-      <Pressable style={[styles.creatorItem, { backgroundColor }]}>
+      <Pressable
+        style={({ pressed }) => [
+          styles.creatorItem,
+          { backgroundColor },
+          pressed && styles.creatorItemPressed,
+        ]}
+      >
         <View style={styles.creatorContent}>
           {creator.cached_image?.url && (
             <Image
@@ -255,7 +261,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, isLast }) => {
   return (
     <Link href={`../atom/${item.term_id}` as any} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           {item.cached_image?.url && (
@@ -421,6 +432,9 @@ const styles = StyleSheet.create({
     minHeight: 44,
     justifyContent: 'center',
   },
+  sectionItemPressed: {
+    opacity: 0.7,
+  },
   sectionItemContent: {
     paddingVertical: 3,
     flexDirection: 'row',
@@ -515,6 +529,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     borderRadius: 10,
+  },
+  creatorItemPressed: {
+    opacity: 0.7,
   },
   creatorContent: {
     flexDirection: 'row',

--- a/app/(tabs)/(lists)/index.tsx
+++ b/app/(tabs)/(lists)/index.tsx
@@ -224,7 +224,12 @@ export const ListItem: React.FC<ListItemProps> = ({ object, isLast }) => {
   return (
     <Link href={`/(lists)/list/${object.term_id}` as any} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           <ComposedImage triples={object.as_object_triples} />
@@ -453,6 +458,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     justifyContent: 'center',
+  },
+  sectionItemPressed: {
+    opacity: 0.7,
   },
   sectionItemContent: {
     paddingVertical: 3,

--- a/app/(tabs)/(me)/index.tsx
+++ b/app/(tabs)/(me)/index.tsx
@@ -122,7 +122,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, isLast }) => {
   return (
     <Link href={`/(me)/atom/${item.term_id}` as any} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           {item.cached_image?.url && (
@@ -218,7 +223,10 @@ export default function MeIndex() {
                   Please switch to Intuition Testnet to view your profile
                 </Text>
                 <Pressable
-                  style={styles.switchChainButton}
+                  style={({ pressed }) => [
+                    styles.switchChainButton,
+                    pressed && styles.switchChainButtonPressed,
+                  ]}
                   onPress={handleSwitchChain}
                 >
                   <Text style={styles.switchChainButtonText}>Add & Switch to Intuition Testnet</Text>
@@ -417,7 +425,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   sectionItemPressed: {
-    opacity: 0.5,
+    opacity: 0.7,
   },
   sectionItemContent: {
     paddingVertical: 3,
@@ -442,6 +450,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     backgroundColor: '#007AFF',
     borderRadius: 8,
+  },
+  switchChainButtonPressed: {
+    opacity: 0.7,
   },
   switchChainButtonText: {
     color: '#FFFFFF',

--- a/app/(tabs)/quests/epochs/[id].tsx
+++ b/app/(tabs)/quests/epochs/[id].tsx
@@ -51,7 +51,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, href, isLast, hasPositi
   return (
     <Link href={href as any} asChild>
       <Pressable
-        style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+        style={({ pressed }) => [
+          styles.sectionItem,
+          { backgroundColor },
+          separator,
+          pressed && styles.sectionItemPressed,
+        ]}
       >
         <View style={styles.sectionItemContent}>
           <Text style={[styles.sectionItemText, { color: textColor }]}>
@@ -197,6 +202,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     justifyContent: 'center',
+  },
+  sectionItemPressed: {
+    opacity: 0.7,
   },
   sectionItemContent: {
     paddingVertical: 3,

--- a/app/(tabs)/quests/index.tsx
+++ b/app/(tabs)/quests/index.tsx
@@ -32,7 +32,12 @@ export default function Quests() {
       {QUESTS.map((quest) => (
         <View key={quest.index} style={[styles.card, { backgroundColor: cardBackground, borderColor }]}>
           <Link href={quest.link} asChild>
-            <Pressable style={styles.cardContent}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.cardContent,
+                pressed && styles.cardContentPressed,
+              ]}
+            >
               <View style={[styles.iconContainer]}>
                 <MaterialIcons
                   name={getIconName(quest.icon)}
@@ -70,6 +75,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-start',
     padding: 20,
+  },
+  cardContentPressed: {
+    opacity: 0.7,
   },
   iconContainer: {
     width: 60,

--- a/app/(tabs)/quests/question/[id].tsx
+++ b/app/(tabs)/quests/question/[id].tsx
@@ -92,7 +92,12 @@ const SectionItem: React.FC<SectionItemProps> = ({ item, isLast, isSelected, onS
 
   return (
     <Pressable
-      style={{ ...styles.sectionItem, backgroundColor, ...separator }}
+      style={({ pressed }) => [
+        styles.sectionItem,
+        { backgroundColor },
+        separator,
+        pressed && styles.sectionItemPressed,
+      ]}
       onPress={onSelect}
     >
       <View style={styles.sectionItemContent}>
@@ -200,8 +205,14 @@ export default function List() {
       return (
         <View style={styles.loadingContainer}>
           <Text style={styles.loadingText}>Success!</Text>
-          <Pressable onPress={() => router.dismiss(1)}>
-            <Text style={styles.loadingText}>Close</Text>
+          <Pressable
+            style={({ pressed }) => [
+              styles.closeButton,
+              pressed && styles.closeButtonPressed,
+            ]}
+            onPress={() => router.dismiss(1)}
+          >
+            <Text style={styles.closeButtonText}>Close</Text>
           </Pressable>
         </View>
       );
@@ -336,6 +347,25 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     minHeight: 44,
     justifyContent: 'center',
+  },
+  sectionItemPressed: {
+    opacity: 0.7,
+  },
+  closeButton: {
+    marginTop: 16,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    backgroundColor: '#007AFF',
+    borderRadius: 8,
+  },
+  closeButtonPressed: {
+    opacity: 0.7,
+  },
+  closeButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   sectionItemContent: {
     paddingVertical: 3,


### PR DESCRIPTION
Add pressed state opacity change (0.7) to all Pressable components
to provide visual feedback on touch, matching native iOS/Android behavior.